### PR TITLE
docs: use ubuntu-latest in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ jobs:
         ddev_version: [stable, HEAD]
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 


### PR DESCRIPTION
I think these will require less maintenance if we use ubuntu-latest, or at least ubuntu-22.04 (which is currently ubuntu-latest)